### PR TITLE
Feat/ToastContainer 구현

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -10,5 +10,10 @@ module.exports = {
       'warn',
       { allowConstantExport: true },
     ],
+    '@typescript-eslint/no-unused-vars': ['warn', {
+      'argsIgnorePattern': '^_',
+      'varsIgnorePattern': '^_',
+      'ignoreRestSiblings': true
+    }],
   },
 }

--- a/.storybook/preview-body.html
+++ b/.storybook/preview-body.html
@@ -1,0 +1,1 @@
+<div id="toast-root"></div>

--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
   <body>
     <div id="modal-root"></div>
     <div id="root"></div>
+    <div id="toast-root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,8 @@ import TopBar from "./components/TopBar";
 import RightPanel from "./components/common/RightPanel/RightPanel";
 import AppWrapper from "./components/layout/wrapper/AppWrapper";
 import Scene from "./three_components/common/Scene";
+import ToastContainer from "@components/common/ToastContainer.tsx";
+
 const App = () => {
   return (
     <AppWrapper>
@@ -10,6 +12,7 @@ const App = () => {
       <TopBar />
       <RightPanel />
       <Scene />
+      <ToastContainer />
     </AppWrapper>
   );
 };

--- a/src/components/CanvasBar.tsx
+++ b/src/components/CanvasBar.tsx
@@ -12,6 +12,7 @@ import { bgColors, grayColors } from "@/resources/colors/colors";
 import canvasHistoryStore from "@/store/canvasHistoryStore";
 import { action, flowResult } from "mobx";
 import { observer } from "mobx-react";
+import { useToast } from "@hooks/useToast";
 
 interface Props {}
 
@@ -58,6 +59,7 @@ const ButtonGroupName = styled.span`
 
 const CanvasBar = observer((props: Props) => {
   const { primitiveStore } = storeContainer;
+  const { addToast } = useToast();
 
   return (
     <Wrapper>
@@ -77,10 +79,11 @@ const CanvasBar = observer((props: Props) => {
             backgroundImage="/icons/studio/btn_cube.svg"
             hoverBackgroundImage="/icons/studio/btn_cube_active.svg"
             onClick={() => {
+              addToast("큐브가 추가되었습니다"); //[TBD] should be deleted on production
               const storeId = nanoid();
               primitiveStore.addPrimitive(
                 storeId,
-                <CubePrimitive storeId={storeId} />
+                <CubePrimitive storeId={storeId} />,
               );
             }}
           />
@@ -90,10 +93,11 @@ const CanvasBar = observer((props: Props) => {
             backgroundImage="/icons/studio/btn_sphere.svg"
             hoverBackgroundImage="/icons/studio/btn_sphere_active.svg"
             onClick={() => {
+              addToast("구가 추가되었습니다"); //[TBD] should be deleted on production
               const storeId = nanoid();
               primitiveStore.addPrimitive(
                 storeId,
-                <SpherePrimitive storeId={storeId} />
+                <SpherePrimitive storeId={storeId} />,
               );
             }}
           />
@@ -106,7 +110,7 @@ const CanvasBar = observer((props: Props) => {
               const storeId = nanoid();
               primitiveStore.addPrimitive(
                 storeId,
-                <CylinderPrimitive storeId={storeId} />
+                <CylinderPrimitive storeId={storeId} />,
               );
             }}
           />
@@ -119,7 +123,7 @@ const CanvasBar = observer((props: Props) => {
               const storeId = nanoid();
               primitiveStore.addPrimitive(
                 storeId,
-                <ConePrimitive storeId={storeId} />
+                <ConePrimitive storeId={storeId} />,
               );
             }}
           />
@@ -132,7 +136,7 @@ const CanvasBar = observer((props: Props) => {
               const storeId = nanoid();
               primitiveStore.addPrimitive(
                 storeId,
-                <TorusPrimitive storeId={storeId} />
+                <TorusPrimitive storeId={storeId} />,
               );
             }}
           />
@@ -145,7 +149,7 @@ const CanvasBar = observer((props: Props) => {
               const storeId = nanoid();
               primitiveStore.addPrimitive(
                 storeId,
-                <CapsulePrimitive storeId={storeId} />
+                <CapsulePrimitive storeId={storeId} />,
               );
             }}
           />

--- a/src/components/common/Toast.tsx
+++ b/src/components/common/Toast.tsx
@@ -1,14 +1,15 @@
-import {useState, useEffect} from "react";
-import {basicColors, bgColors, grayColors} from "@/resources/colors/colors";
+import { useState, useEffect } from "react";
+import { basicColors, bgColors, grayColors } from "@/resources/colors/colors";
 import { fonts } from "@/resources/fonts/font";
 import { CSSHexColor } from "@/types/style/CssUnits";
 import { FontType } from "@/types/style/Font";
-import styled, {keyframes, css} from "styled-components";
+import styled, { keyframes, css } from "styled-components";
 
 export type ToastProps = {
   label: string;
   fadeOut?: boolean;
   fadeIn?: boolean;
+  onClose?: () => void;
   fontSize?: FontType;
   color?: CSSHexColor;
   backgroundColor?: CSSHexColor;
@@ -67,12 +68,16 @@ const StyledToast = styled.button<CSSProps>`
   vertical-align: middle;
   animation: ${({ $fadeOut, $fadeIn }) => {
     if ($fadeIn) {
-      return css`${fadeInAnimation} 0.5s ease-in-out`;
+      return css`
+        ${fadeInAnimation} 0.5s ease-in-out
+      `;
     }
     if ($fadeOut) {
-      return css`${fadeOutAnimation} 0.5s ease-in-out forwards`;
+      return css`
+        ${fadeOutAnimation} 0.5s ease-in-out forwards
+      `;
     }
-    return 'none';
+    return "none";
   }};
 `;
 
@@ -80,6 +85,7 @@ const Toast = ({
   fadeOut = true,
   fadeIn = true,
   label,
+  onClose = () => {},
   color = basicColors.lightLimeGreen,
   backgroundColor = bgColors[222222],
   fontSize = "small",
@@ -92,8 +98,7 @@ const Toast = ({
   fontFamily = "SourceHanSansKR",
   fontWeight = 500,
   duration = 3000,
-                    }: ToastProps) => {
-
+}: ToastProps) => {
   const [isVisible, setIsVisible] = useState(true);
   const [isFadingOut, setIsFadingOut] = useState(false);
 
@@ -116,6 +121,7 @@ const Toast = ({
 
   return (
     <StyledToast
+      onClick={onClose}
       $fadeIn={fadeIn && !isFadingOut}
       $fadeOut={isFadingOut}
       $backgroundColor={backgroundColor}

--- a/src/components/common/ToastContainer.tsx
+++ b/src/components/common/ToastContainer.tsx
@@ -1,0 +1,46 @@
+import { createPortal } from "react-dom";
+import { useToast } from "@hooks/useToast";
+import Toast from "@components/common/Toast";
+import styled from "styled-components";
+import { ToastPosition, POSITION_VARIANTS } from "@/types/style/ToastPosition";
+
+interface ToastContainerProps {
+  position?: ToastPosition;
+}
+
+const ToastContainer = ({ position = "topCenter" }: ToastContainerProps) => {
+  const { toastMessages, removeToast } = useToast();
+
+  const toastRoot = document.getElementById("toast-root");
+  if (!toastRoot) {
+    console.warn("toast-root element is missing in DOM");
+    return null;
+  }
+
+  return createPortal(
+    <StyledToastContainer position={position}>
+      {toastMessages
+        .map((message) => (
+          <Toast
+            key={message.id}
+            label={message.content}
+            onClose={() => removeToast(message.id)}
+          />
+        ))
+        .reverse()}
+    </StyledToastContainer>,
+    toastRoot,
+  );
+};
+
+const StyledToastContainer = styled.div<{ position: ToastPosition }>`
+  position: fixed;
+  ${({ position }) => ({ ...POSITION_VARIANTS[position] })};
+  z-index: 1000;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+`;
+
+export default ToastContainer;

--- a/src/hooks/useToast.ts
+++ b/src/hooks/useToast.ts
@@ -1,0 +1,55 @@
+import { useState, useEffect, useRef } from "react";
+import { nanoid } from "nanoid";
+
+/**
+ * @description
+ * This hook is for managing toast messages.
+ * id would be unique identifier, it will be "key" of the component list
+ * <ToastContainer> will use id whether the message is new or not
+ * it leads reference of judging whether render or not
+ */
+type ToastMessage = {
+  id: string;
+  content: string;
+};
+
+let listeners: Array<() => void> = [];
+let toastMessages: ToastMessage[] = []; //this toastMessages will globally available
+const MAX_TOAST_QUEUE_COUNT = 3; //ToastContainer will slice toastMessages under this number
+
+export function useToast() {
+  const [_, forceUpdate] = useState<object>({});
+  const currentListener = useRef<() => void>(() => forceUpdate({})); //forceUpdating with setting empty object
+
+  const addToast = (content: string) => {
+    const newMessage = {
+      id: nanoid(),
+      content,
+    };
+
+    // Keep only MAX_TOAST_QUEUE_COUNT messages, it will be sliced by <ToastContainer>
+    toastMessages = [newMessage, ...toastMessages].slice(
+      0,
+      MAX_TOAST_QUEUE_COUNT
+    );
+    listeners.forEach((listener) => listener());
+  };
+
+  // Here's reason for removeToast:
+  // Some time, toast hidden important UI element
+  // So, we need to remove toast when user click the toast
+  const removeToast = (id: string) => {
+    toastMessages = toastMessages.filter((message) => message.id !== id);
+    listeners.forEach((listener) => listener());
+  };
+
+  useEffect(() => {
+    const current = currentListener.current;
+    listeners.push(current);
+    return () => {
+      listeners = listeners.filter((listener) => listener !== current);
+    };
+  }, []);
+
+  return { toastMessages, addToast, removeToast };
+}

--- a/src/stories/Toasts/Toast.stories.ts
+++ b/src/stories/Toasts/Toast.stories.ts
@@ -39,7 +39,6 @@ export const ShortTimeToast = {
   },
 } satisfies Story;
 
-
 export const CustomizedToastLasting7seconds = {
   args: {
     label: "닫기",

--- a/src/stories/Toasts/ToastContainer.stories.tsx
+++ b/src/stories/Toasts/ToastContainer.stories.tsx
@@ -1,0 +1,21 @@
+import ToastContainerTest from "./ToastContainerTest";
+import type { Meta, StoryObj } from "@storybook/react";
+
+const meta = {
+  component: ToastContainerTest,
+  title: "Component/Common/ToastContainer",
+  tags: ["autodocs"],
+} satisfies Meta<typeof ToastContainerTest>;
+
+export default meta;
+type Story = StoryObj<typeof ToastContainerTest>;
+
+export const Default = {
+  args: {},
+} satisfies Story;
+
+export const PositionBottomLeft = {
+  args: {
+    position: "bottomLeft",
+  },
+} satisfies Story;

--- a/src/stories/Toasts/ToastContainerTest.tsx
+++ b/src/stories/Toasts/ToastContainerTest.tsx
@@ -1,0 +1,29 @@
+import { useToast } from "@hooks/useToast";
+import ToastContainer from "@components/common/ToastContainer";
+import { ToastPosition } from "@/types/style/ToastPosition";
+
+interface ToastContainerTestProps {
+  position?: ToastPosition;
+}
+
+const ToastContainerTest = ({
+  position = "topCenter",
+}: ToastContainerTestProps) => {
+  const { addToast } = useToast();
+
+  const addToastMessage = () => addToast("토스트 추가하기를 누르셨습니다");
+  const addLongToastMessage = () =>
+    addToast("길~~~~고 길~~~다란 토스트를 추가하셨습니다!");
+  const addHi = () => addToast("안녕");
+
+  return (
+    <div>
+      <button onClick={addToastMessage}>토스트 추가하기</button>
+      <button onClick={addLongToastMessage}>길~다란 토스트 추가하기</button>
+      <button onClick={addHi}> "안녕" 추가하기</button>
+      <ToastContainer position={position} />
+    </div>
+  );
+};
+
+export default ToastContainerTest;

--- a/src/types/style/ToastPosition.ts
+++ b/src/types/style/ToastPosition.ts
@@ -1,0 +1,41 @@
+import { CSSProperties } from "react";
+
+type ToastPosition =
+  | "topCenter"
+  | "topLeft"
+  | "topRight"
+  | "bottomLeft"
+  | "bottomCenter"
+  | "bottomRight";
+
+const POSITION_VARIANTS: Record<ToastPosition, CSSProperties> = {
+  topCenter: {
+    top: "10%",
+    left: "50%",
+    transform: "translateX(-50%)",
+  },
+  topLeft: {
+    top: "10%",
+    left: "10%",
+  },
+  topRight: {
+    top: "10%",
+    right: "10%",
+  },
+  bottomLeft: {
+    bottom: "10%",
+    left: "10%",
+  },
+  bottomCenter: {
+    bottom: "10%",
+    left: "50%",
+    transform: "translateX(-50%)",
+  },
+  bottomRight: {
+    bottom: "10%",
+    right: "10%",
+  },
+};
+
+export type { ToastPosition };
+export { POSITION_VARIANTS };


### PR DESCRIPTION
## 🛞 주요 커밋 내역

### 컴포넌트 구현한 주요 부분
- src/components/common/ToastContainer.tsx
- src/hooks/use-toast.ts

### 작동
- 토스트컨테이너가 가질 수 있는 `최대 메시지 갯수`를 설정할 수 있습니다
- 토스트컨테이너의 `위치`를 설정할 수 있습니다


## 🚀토스트 사용방법
```javascript
const {addToast} = useToast()

//필요한곳에서
addToast("저장이 완료되었습니다")
```

## 🤔기타
- `eslintrc`에 `no-unused-var` 규칙 추가했습니다. "_" 언더스코어 앞에 있으면, 안써도 `warning` 안뜨도록 했습니다.
- storybook에 preview관련 html없어서, `preview-body.html`추가했습니다.
  + `createPortal`로 toast연결시키도록 구현해서, storybook에도 해당 id가진 <div> 추가해줬습니다.
- 구, 큐브 추가할때 토스트메시지 달도록 연결시켜두었습니다.
  + 작동예시겸, 실사용 테스트겸 올려두었습니다. 추후 제거하겠습니다.
