### PR TITLE
fix: 창 사이즈 변경 시 스크롤바 생기는 현상(canvas 크기 고정)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -52,6 +52,8 @@ const Header = styled.header``;
 const Main = styled.main`
   position: relative;
   flex: 1;
+  min-height: 0;
+  min-width: 0;
 `;
 
 const EditorWrapper = styled.div<{ $visible: boolean }>`


### PR DESCRIPTION
## 📌 `Pull Request` 관련 내용 공유

### 📋 PR 설명

- 창 사이즈 변경 시(사이즈 줄일 시) 캔버스의 크기가 고정되어 스크롤바가 생기는 현상 수정
  - flex 사용 시 min 사이즈가 child(canvas)의 사이즈로 고정되어 생기는 현상으로 canvas의 parent를 min-width, min-height=0로 설정하여 해결
  - 참고: https://stackoverflow.com/questions/76940083/react-three-fiber-canvas-stretches-its-parent-and-becomes-unresponsive



### 📡 핵심 기능

- 



### 📸 시각 자료(캡처 화면)

before
![before](https://github.com/Rebuild-Studio/Client/assets/53351097/92a369dd-92d3-49b3-9b5f-21c6e83f5523)

after
![after](https://github.com/Rebuild-Studio/Client/assets/53351097/8230e6e3-3dbf-4cea-bf47-5413721c1119)





### 🛠️ 이슈 및 앞으로 할 일

- 



<br>



## 🤖 `PR` 셀프 체크리스트 🤖

> 코드 확인 후 `[ ]`사이 공백을 `x`로 체크하시오

<br>



### ⌨️ 코드 컨벤션!

- [ ] 불필요한 console 디버깅 코드는 제거했나요? (스토리북 예외)
    - `console.log(selectedObject[0])`



- [ ] 변수명 혹은 파일명이 너무 추상적이지는 않나요?
  - `setType` -> `setBackgroundColorType ` 



- [ ] 불필요한 공백을 제거하셨나요?

    - ```react
      <AppWrapper>
        <MenuBar />
        <Scene />
                          // <- X
      </AppWrapper>
      ```



- [ ] 불필요한 주석을 제거하셨나요?

    - ```react
      // primitiveStore.addPrimitive(                          // <- X
      //   storeId,                                            // <- X
      //   renderSelectedGroup(storeId, mesh.clone())          // <- X
      // );                                                    // <- X
      ```



<br>