### PR TITLE
fix : assetPrimtive 에셋 일부분 로드 안되는 버그 해결

### DIFF
--- a/src/three_components/assets/AssetPrimitive.tsx
+++ b/src/three_components/assets/AssetPrimitive.tsx
@@ -14,31 +14,35 @@ const AssetPrimitive = observer(
   ({ url, propMesh, storeId }: AssetPrimitveProps) => {
     const ref = useRef();
     const { primitiveStore } = storeContainer;
-    let mesh: THREE.Mesh;
 
+    let object: THREE.Object3D;
     if (url) {
-      const group = useServerGLTFLoader(url).scene;
-      mesh = (group.children[0].clone() as THREE.Mesh) ?? propMesh;
+      const loadedData = useServerGLTFLoader(url);
+      if (!(loadedData instanceof THREE.Group)) {
+        object = loadedData.scene;
+      } else {
+        object = loadedData;
+      }
     } else if (propMesh) {
-      mesh = propMesh;
+      object = propMesh;
     } else {
       return <></>;
     }
+
+    const mesh = new THREE.Mesh();
 
     mesh.name = "ASSET";
     mesh.userData["storeId"] = storeId;
     mesh.userData["isLocked"] = false;
 
     useEffect(() => {
-      primitiveStore.updatePrimitive(
-        mesh.userData["storeId"],
-        mesh as THREE.Mesh
-      );
+      mesh.attach(object);
+      primitiveStore.updatePrimitive(mesh.userData["storeId"], mesh);
       canvasHistoryStore.differAdd(mesh.userData["storeId"]);
     }, []);
 
     return (
-      <primitive ref={ref} object={primitiveStore.meshes[storeId] ?? mesh} />
+      <primitive ref={ref} object={primitiveStore.meshes[storeId] ?? object} />
     );
   }
 );


### PR DESCRIPTION
## 📌 `Pull Request` 관련 내용 공유

### 📋 PR 설명

- minio의 일부 에셋들 중에서 제대로 렌더가 되지 않는 버그가 있어서 고쳤습니다.



### 📡 핵심 기능

- 



### 📸 시각 자료(캡처 화면)





### 🛠️ 이슈 및 앞으로 할 일

- 



<br>



## 🤖 `PR` 셀프 체크리스트 🤖

> 코드 확인 후 `[ ]`사이 공백을 `x`로 체크하시오

<br>



### ⌨️ 코드 컨벤션!

- [ ] 불필요한 console 디버깅 코드는 제거했나요? (스토리북 예외)
    - `console.log(selectedObject[0])`



- [ ] 변수명 혹은 파일명이 너무 추상적이지는 않나요?
  - `setType` -> `setBackgroundColorType ` 



- [ ] 불필요한 공백을 제거하셨나요?

    - ```react
      <AppWrapper>
        <MenuBar />
        <Scene />
                          // <- X
      </AppWrapper>
      ```



- [ ] 불필요한 주석을 제거하셨나요?

    - ```react
      // primitiveStore.addPrimitive(                          // <- X
      //   storeId,                                            // <- X
      //   renderSelectedGroup(storeId, mesh.clone())          // <- X
      // );                                                    // <- X
      ```



<br>