### PR TITLE
fix: 인터렉션 에디터 레이아웃

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,14 +10,11 @@ import styled from "styled-components";
 import TopBar from "@components/TopBar";
 import Tools from "@components/layout/Tools";
 import editorModeStore from "@store/editorModeStore.ts";
-import InteractionTopBar from "@/interaction(legacyJS)/src/Components/views/00. Common/TopBar_V";
-import InteractionPanel from "@/interaction(legacyJS)/src/Components/views/02. Studio/04. EventPanel/InteractionPanel.jsx";
-import { I18nextProvider } from "react-i18next";
-import i18n from "@/interaction(legacyJS)/src/locale/i18n.js";
+import InteractionEditor from "@components/InteractionEditor.tsx";
 
 const App = observer(() => {
   const { projectStateStore } = storeContainer;
-  const { editorMode, interactionBarOpen } = editorModeStore;
+  const { editorMode } = editorModeStore;
 
   return (
     <>
@@ -32,10 +29,7 @@ const App = observer(() => {
             <Tools />
           </EditorWrapper>
           <EditorWrapper $visible={editorMode === "interaction"}>
-            <I18nextProvider i18n={i18n}>
-              {interactionBarOpen && <InteractionTopBar />}
-              <InteractionPanel />
-            </I18nextProvider>
+            <InteractionEditor />
           </EditorWrapper>
         </Main>
       </AppWrapper>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,8 @@ import Tools from "@components/layout/Tools";
 import editorModeStore from "@store/editorModeStore.ts";
 import InteractionTopBar from "@/interaction(legacyJS)/src/Components/views/00. Common/TopBar_V";
 import InteractionPanel from "@/interaction(legacyJS)/src/Components/views/02. Studio/04. EventPanel/InteractionPanel.jsx";
+import { I18nextProvider } from "react-i18next";
+import i18n from "@/interaction(legacyJS)/src/locale/i18n.js";
 
 const App = observer(() => {
   const { projectStateStore } = storeContainer;
@@ -30,8 +32,10 @@ const App = observer(() => {
             <Tools />
           </EditorWrapper>
           <EditorWrapper $visible={editorMode === "interaction"}>
-            {interactionBarOpen && <InteractionTopBar />}
-            <InteractionPanel />
+            <I18nextProvider i18n={i18n}>
+              {interactionBarOpen && <InteractionTopBar />}
+              <InteractionPanel />
+            </I18nextProvider>
           </EditorWrapper>
         </Main>
       </AppWrapper>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,31 +7,31 @@ import ToastContainer from "@components/common/ToastContainer";
 import Modal from "./components/layout/modal/Modal";
 import ReactDOM from "react-dom";
 import styled from "styled-components";
-import { useState } from "react";
 import TopBar from "@components/TopBar";
 import Tools from "@components/layout/Tools";
-import InteractionEditor from "@/interaction(legacyJS)/src/App";
 import editorModeStore from "@store/editorModeStore.ts";
+import InteractionTopBar from "@/interaction(legacyJS)/src/Components/views/00. Common/TopBar_V";
+import InteractionPanel from "@/interaction(legacyJS)/src/Components/views/02. Studio/04. EventPanel/InteractionPanel.jsx";
 
 const App = observer(() => {
   const { projectStateStore } = storeContainer;
-  const [canvasBarOpen, setCanvasBarOpen] = useState(true);
-  const { editorMode } = editorModeStore;
+  const { editorMode, interactionBarOpen } = editorModeStore;
 
   return (
     <>
       <AppWrapper>
         <Header>
           <MenuBar />
-          <TopBar isOpen={canvasBarOpen} setOpen={setCanvasBarOpen} />
+          <TopBar />
         </Header>
         <Main>
           <EditorWrapper $visible={editorMode === "canvas"}>
             <Scene />
-            <Tools canvasBarIsOpen={canvasBarOpen} />
+            <Tools />
           </EditorWrapper>
           <EditorWrapper $visible={editorMode === "interaction"}>
-            <InteractionEditor />
+            {interactionBarOpen && <InteractionTopBar />}
+            <InteractionPanel />
           </EditorWrapper>
         </Main>
       </AppWrapper>
@@ -59,4 +59,5 @@ const Main = styled.main`
 const EditorWrapper = styled.div<{ $visible: boolean }>`
   display: ${({ $visible }) => ($visible ? "block" : "none")};
   height: 100%;
+  position: relative;
 `;

--- a/src/components/InteractionEditor.tsx
+++ b/src/components/InteractionEditor.tsx
@@ -6,12 +6,12 @@ import editorModeStore from "@store/editorModeStore.ts";
 import { observer } from "mobx-react";
 
 const InteractionEditor = observer(() => {
-  const { interactionBarOpen } = editorModeStore;
+  const { interactionBarOpen, editorMode } = editorModeStore;
 
   return (
     <I18nextProvider i18n={i18n}>
       {interactionBarOpen && <InteractionTopBar />}
-      <InteractionPanel />
+      {editorMode === "interaction" && <InteractionPanel />}
     </I18nextProvider>
   );
 });

--- a/src/components/InteractionEditor.tsx
+++ b/src/components/InteractionEditor.tsx
@@ -1,0 +1,19 @@
+import InteractionTopBar from "@/interaction(legacyJS)/src/Components/views/00. Common/TopBar_V";
+import InteractionPanel from "@/interaction(legacyJS)/src/Components/views/02. Studio/04. EventPanel/InteractionPanel.jsx";
+import { I18nextProvider } from "react-i18next";
+import i18n from "@/interaction(legacyJS)/src/locale/i18n.js";
+import editorModeStore from "@store/editorModeStore.ts";
+import { observer } from "mobx-react";
+
+const InteractionEditor = observer(() => {
+  const { interactionBarOpen } = editorModeStore;
+
+  return (
+    <I18nextProvider i18n={i18n}>
+      {interactionBarOpen && <InteractionTopBar />}
+      <InteractionPanel />
+    </I18nextProvider>
+  );
+});
+
+export default InteractionEditor;

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -5,7 +5,7 @@ import { basicColors } from "@/resources/colors/colors";
 import storeContainer from "@/store/storeContainer";
 import { fonts } from "@resources/fonts/font";
 import editorModeStore from "@store/editorModeStore";
-import { observer } from "mobx-react-lite";
+import { observer } from "mobx-react";
 
 const TopBar = observer(() => {
   const { sceneSettingStore, primitiveStore } = storeContainer;

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -7,14 +7,10 @@ import { fonts } from "@resources/fonts/font";
 import editorModeStore from "@store/editorModeStore";
 import { observer } from "mobx-react-lite";
 
-interface TopBarProps {
-  isOpen: boolean;
-  setOpen: React.Dispatch<React.SetStateAction<boolean>>;
-}
-
-const TopBar = observer(({ isOpen, setOpen }: TopBarProps) => {
+const TopBar = observer(() => {
   const { sceneSettingStore, primitiveStore } = storeContainer;
-  const { editorMode, setEditorMode } = editorModeStore;
+  const { editorMode, setEditorMode, toggleCanvasBar, toggleInteractionBar } =
+    editorModeStore;
 
   return (
     <Wrapper>
@@ -24,7 +20,7 @@ const TopBar = observer(({ isOpen, setOpen }: TopBarProps) => {
           shadow="none"
           onClick={() => {
             if (editorMode === "canvas") {
-              setOpen(!isOpen);
+              toggleCanvasBar();
             } else {
               setEditorMode("canvas");
             }
@@ -35,7 +31,11 @@ const TopBar = observer(({ isOpen, setOpen }: TopBarProps) => {
           label="인터렉션 에디터"
           shadow="none"
           onClick={() => {
-            setEditorMode("interaction");
+            if (editorMode === "interaction") {
+              toggleInteractionBar();
+            } else {
+              setEditorMode("interaction");
+            }
           }}
           color={
             editorMode === "interaction" ? basicColors.white : basicColors.grey

--- a/src/components/layout/Tools.tsx
+++ b/src/components/layout/Tools.tsx
@@ -6,7 +6,7 @@ import RightPanel from "@components/common/RightPanel/RightPanel";
 import ControllerBar from "@/features/controllerBar";
 import styled from "styled-components";
 import storeContainer from "@store/storeContainer";
-import { observer } from "mobx-react-lite";
+import { observer } from "mobx-react";
 import editorModeStore from "@store/editorModeStore.ts";
 
 const Tools = observer(() => {

--- a/src/components/layout/Tools.tsx
+++ b/src/components/layout/Tools.tsx
@@ -7,18 +7,16 @@ import ControllerBar from "@/features/controllerBar";
 import styled from "styled-components";
 import storeContainer from "@store/storeContainer";
 import { observer } from "mobx-react-lite";
+import editorModeStore from "@store/editorModeStore.ts";
 
-interface Props {
-  canvasBarIsOpen: boolean;
-}
-
-const Tools = observer(({ canvasBarIsOpen }: Props) => {
+const Tools = observer(() => {
   const { sceneSettingStore } = storeContainer;
+  const { canvasBarOpen } = editorModeStore;
 
   return (
     <>
       <Layout>
-        <Top>{canvasBarIsOpen && <CanvasBar />}</Top>
+        <Top>{canvasBarOpen && <CanvasBar />}</Top>
         <Bottom>
           <Left>
             <CanvasLeftPanel />

--- a/src/components/layout/contextMenu/ContextMenu.tsx
+++ b/src/components/layout/contextMenu/ContextMenu.tsx
@@ -1,7 +1,7 @@
 import { basicColors, bgColors, grayColors } from "@/resources/colors/colors";
 import { ContextMenuItemType } from "@/store/contextMenuStore";
 import storeContainer from "@/store/storeContainer";
-import { observer } from "mobx-react-lite";
+import { observer } from "mobx-react";
 import { styled } from "styled-components";
 
 interface ContextMenuProps extends ContextMenuPositionProps {

--- a/src/features/controllerBar/components/gizmo/GizmoMode.tsx
+++ b/src/features/controllerBar/components/gizmo/GizmoMode.tsx
@@ -1,4 +1,4 @@
-import { observer } from "mobx-react-lite";
+import { observer } from "mobx-react";
 
 import ControlDropdown from "@/features/controllerBar/components/dropdown/ControlDropdown";
 import GizmoModeControl from "./GizmoModeControl";

--- a/src/features/controllerBar/components/gizmo/GizmoModeControl.tsx
+++ b/src/features/controllerBar/components/gizmo/GizmoModeControl.tsx
@@ -1,6 +1,6 @@
 import { FormEvent } from "react";
 import { styled } from "styled-components";
-import { observer } from "mobx-react-lite";
+import { observer } from "mobx-react";
 
 import RadioInput from "@/features/controllerBar/components/gizmo/RadioInput";
 import { GIZMO_MODE } from "@/features/controllerBar/constants/gizmo";

--- a/src/features/controllerBar/components/snap/ActivateAxis.tsx
+++ b/src/features/controllerBar/components/snap/ActivateAxis.tsx
@@ -1,4 +1,4 @@
-import { observer } from "mobx-react-lite";
+import { observer } from "mobx-react";
 import { css, styled } from "styled-components";
 
 import { basicColors, bgColors, grayColors } from "@resources/colors/colors";

--- a/src/features/controllerBar/components/snap/SnapMode.tsx
+++ b/src/features/controllerBar/components/snap/SnapMode.tsx
@@ -1,4 +1,4 @@
-import { observer } from "mobx-react-lite";
+import { observer } from "mobx-react";
 
 import SnapModeControl from "@/features/controllerBar/components/snap/SnapModeControl";
 import ControlDropdown from "@/features/controllerBar/components/dropdown/ControlDropdown";

--- a/src/features/controllerBar/components/snap/SnapModeControl.tsx
+++ b/src/features/controllerBar/components/snap/SnapModeControl.tsx
@@ -1,6 +1,6 @@
 import { FormEvent } from "react";
 import { styled } from "styled-components";
-import { observer } from "mobx-react-lite";
+import { observer } from "mobx-react";
 
 import ActivateAxis from "@/features/controllerBar/components/snap/ActivateAxis";
 import Checkbox from "@/features/controllerBar/components/snap/Checkbox";

--- a/src/interaction(legacyJS)/src/App.jsx
+++ b/src/interaction(legacyJS)/src/App.jsx
@@ -1,5 +1,5 @@
 import Root from "./Components/views/00. Common/Root_V";
-import { observer } from "mobx-react-lite";
+import { observer } from "mobx-react";
 import React from "react";
 import { I18nextProvider } from "react-i18next";
 import i18n from "../src/locale/i18n";

--- a/src/interaction(legacyJS)/src/Components/views/00. Common/Interaction/TopBarInteraction.jsx
+++ b/src/interaction(legacyJS)/src/Components/views/00. Common/Interaction/TopBarInteraction.jsx
@@ -254,11 +254,9 @@ const style = {
 
   topBarEventContainer: {
     position: "fixed",
-    top: "90px",
-    height: "87px",
-    width: "100%",
     backgroundColor: "#282828",
     display: "flex",
+    width: "100%",
     justifyContent: "center",
     alignItems: "center",
     flexDirection: "column",

--- a/src/interaction(legacyJS)/src/Components/views/00. Common/Root_V.jsx
+++ b/src/interaction(legacyJS)/src/Components/views/00. Common/Root_V.jsx
@@ -1,6 +1,6 @@
 import { Box } from "@mui/material";
 import TopBar from "./TopBar_V";
-import { observer } from "mobx-react-lite";
+import { observer } from "mobx-react";
 import React from "react";
 import InteractionPanel from "../02. Studio/04. EventPanel/InteractionPanel";
 

--- a/src/interaction(legacyJS)/src/Components/views/00. Common/SliderButton_V.jsx
+++ b/src/interaction(legacyJS)/src/Components/views/00. Common/SliderButton_V.jsx
@@ -1,4 +1,4 @@
-import { observer } from "mobx-react-lite";
+import { observer } from "mobx-react";
 import { IconButton, Box } from "@mui/material";
 import React, { useState } from "react";
 import TextTransition from "./SliderButtonTextTransition";

--- a/src/interaction(legacyJS)/src/Components/views/00. Common/TopBar_V.jsx
+++ b/src/interaction(legacyJS)/src/Components/views/00. Common/TopBar_V.jsx
@@ -1,37 +1,26 @@
-import { AppBar, Box } from "@mui/material";
+import { AppBar, Box } from "@mui/material"; // 지우면 에러..
 import React from "react";
 import { observer } from "mobx-react-lite";
 import TopBarEvent from "./Interaction/TopBarInteraction";
+import styled from "styled-components";
 
 const TopBar = observer(() => {
   return (
-    <Box sx={style.wrapper}>
-      <AppBar
-        sx={style.appBar}
-        onDragStart={(e) => {
-          e.preventDefault();
-        }}
-      >
-        <TopBarEvent />
-      </AppBar>
-    </Box>
+    <Wrapper
+      onDragStart={(e) => {
+        e.preventDefault();
+      }}
+    >
+      <TopBarEvent />
+    </Wrapper>
   );
 });
 export default TopBar;
 
-const style = {
-  wrapper: {
-    width: "100%",
-    height: "78px",
-  },
-
-  appBar: {
-    width: "100%",
-    boxShadow: 0,
-    overflow: "hidden",
-    display: "flex",
-    justifyContent: "flex-start",
-    backgroundColor: "transparent",
-    userSelect: "none",
-  },
-};
+const Wrapper = styled.div`
+  z-index: 10;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+`;

--- a/src/interaction(legacyJS)/src/Components/views/00. Common/TopBar_V.jsx
+++ b/src/interaction(legacyJS)/src/Components/views/00. Common/TopBar_V.jsx
@@ -1,6 +1,6 @@
 import { AppBar, Box } from "@mui/material"; // 지우면 에러..
 import React from "react";
-import { observer } from "mobx-react-lite";
+import { observer } from "mobx-react";
 import TopBarEvent from "./Interaction/TopBarInteraction";
 import styled from "styled-components";
 

--- a/src/interaction(legacyJS)/src/Components/views/00. Common/TopBar_V.jsx
+++ b/src/interaction(legacyJS)/src/Components/views/00. Common/TopBar_V.jsx
@@ -1,4 +1,4 @@
-import { AppBar, Box } from "@mui/material"; // 지우면 에러..
+import { AppBar, Box } from "@mui/material"; // fixme: 해당 import 지우면 에러 (createTheme_default is not a function at Box.js:8:22)
 import React from "react";
 import { observer } from "mobx-react";
 import TopBarEvent from "./Interaction/TopBarInteraction";

--- a/src/interaction(legacyJS)/src/Components/views/02. Studio/02. RightTab/commandGUI/MxColor9988_V.jsx
+++ b/src/interaction(legacyJS)/src/Components/views/02. Studio/02. RightTab/commandGUI/MxColor9988_V.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Box, Button, Typography, Menu } from "@mui/material";
-import { observer } from "mobx-react-lite";
+import { observer } from "mobx-react";
 import { Hue, Saturation, Alpha } from "@uiw/react-color";
 import { hsvaToRgba, hsvaToHex } from "@uiw/color-convert";
 import Common_VM from "../../../../view_models/Common_VM";

--- a/src/interaction(legacyJS)/src/Components/views/02. Studio/02. RightTab/gui/LightColor_V.jsx
+++ b/src/interaction(legacyJS)/src/Components/views/02. Studio/02. RightTab/gui/LightColor_V.jsx
@@ -1,5 +1,5 @@
 import { Box, Button, Typography, Menu } from "@mui/material";
-import { observer } from "mobx-react-lite";
+import { observer } from "mobx-react";
 import { Hue, Saturation } from "@uiw/react-color";
 import { hsvaToRgba, hsvaToHex } from "@uiw/color-convert";
 import Common_VM from "../../../../view_models/Common_VM";

--- a/src/interaction(legacyJS)/src/Components/views/02. Studio/02. RightTab/gui/MxColor_V.jsx
+++ b/src/interaction(legacyJS)/src/Components/views/02. Studio/02. RightTab/gui/MxColor_V.jsx
@@ -1,5 +1,5 @@
 import { Box, Button, Typography, Menu } from "@mui/material";
-import { observer } from "mobx-react-lite";
+import { observer } from "mobx-react";
 import { Hue, Saturation, Alpha } from "@uiw/react-color";
 import {
   hsvaToRgba,
@@ -428,7 +428,7 @@ const style = {
       typeof color !== "undefined" &&
       `rgba(${rgbColor.r},${rgbColor.g},${rgbColor.b},${rgbColor.a})`
     }`,
-    ...buttonStyle
+    ...buttonStyle,
   }),
   colorMenu: (menuStyle) => ({
     zIndex: 10000,

--- a/src/interaction(legacyJS)/src/Components/views/02. Studio/03. MainPanel/InteractionRuntime.js
+++ b/src/interaction(legacyJS)/src/Components/views/02. Studio/03. MainPanel/InteractionRuntime.js
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from "react";
-import { observer } from "mobx-react-lite";
+import { observer } from "mobx-react";
 import { useThree, useFrame } from "@react-three/fiber";
 import storeContainer from "../../../stores/storeContainer";
 import NodeRuntimeArguments from "../../../class/event-system/runtime/NodeRuntimeArguments";

--- a/src/interaction(legacyJS)/src/Components/views/02. Studio/03. MainPanel/SceneHelpers.js
+++ b/src/interaction(legacyJS)/src/Components/views/02. Studio/03. MainPanel/SceneHelpers.js
@@ -2,7 +2,7 @@ import React, { useMemo, useRef, useEffect } from "react";
 import { useFrame, useThree } from "@react-three/fiber";
 import * as THREE from "three";
 import storeContainer from "../../../stores/storeContainer";
-import { observer } from "mobx-react-lite";
+import { observer } from "mobx-react";
 
 const SceneHelpers = observer(() => {
   const { scene_store } = storeContainer;

--- a/src/interaction(legacyJS)/src/Components/views/02. Studio/03. MainPanel/SceneSetting.js
+++ b/src/interaction(legacyJS)/src/Components/views/02. Studio/03. MainPanel/SceneSetting.js
@@ -1,5 +1,5 @@
 import { useEffect, useLayoutEffect, useState } from "react";
-import { observer } from "mobx-react-lite";
+import { observer } from "mobx-react";
 import storeContainer from "../../../stores/storeContainer";
 import { useFrame, useThree } from "@react-three/fiber";
 import EventFunctions_VM from "../../../view_models/EventFunctions_VM";

--- a/src/interaction(legacyJS)/src/Components/views/02. Studio/04. EventPanel/DragAreaSelectionBox_V.jsx
+++ b/src/interaction(legacyJS)/src/Components/views/02. Studio/04. EventPanel/DragAreaSelectionBox_V.jsx
@@ -1,4 +1,4 @@
-import { observer } from "mobx-react-lite";
+import { observer } from "mobx-react";
 import { useState } from "react";
 import { createPortal } from "react-dom";
 import styled from "@emotion/styled";
@@ -35,24 +35,36 @@ const DragAreaSelectionBox = observer(() => {
 
   const handleMouseUp = () => {
     setIsDrawing(false);
-    dragAreaSelectionBoxViewModel.selectMultipleNodesAndGroupsFromSelectionBox(box);
+    dragAreaSelectionBoxViewModel.selectMultipleNodesAndGroupsFromSelectionBox(
+      box
+    );
     setBox({ x: 0, y: 0, width: 0, height: 0 });
   };
 
-  return common_store.curCategory === "event" && isShiftPressed && createPortal(
-    <FullscreenOverlay
-      onMouseDown={handleMouseDown}
-      onMouseMove={handleMouseMove}
-      onMouseUp={handleMouseUp}
-    >
-      {isDrawing && <SelectionBox x={box.x} y={box.y} width={box.width} height={box.height} />}
-    </FullscreenOverlay>,
-    portalElement
+  return (
+    common_store.curCategory === "event" &&
+    isShiftPressed &&
+    createPortal(
+      <FullscreenOverlay
+        onMouseDown={handleMouseDown}
+        onMouseMove={handleMouseMove}
+        onMouseUp={handleMouseUp}
+      >
+        {isDrawing && (
+          <SelectionBox
+            x={box.x}
+            y={box.y}
+            width={box.width}
+            height={box.height}
+          />
+        )}
+      </FullscreenOverlay>,
+      portalElement
+    )
   );
 });
 
 export default DragAreaSelectionBox;
-
 
 const FullscreenOverlay = styled.div`
   position: fixed;
@@ -71,5 +83,5 @@ const SelectionBox = styled.div`
   top: ${(props) => props.y}px;
   width: ${(props) => props.width}px;
   height: ${(props) => props.height}px;
-  border: 2px dashed #D4ED3E;
+  border: 2px dashed #d4ed3e;
 `;

--- a/src/interaction(legacyJS)/src/Components/views/02. Studio/04. EventPanel/InteractionPanel.jsx
+++ b/src/interaction(legacyJS)/src/Components/views/02. Studio/04. EventPanel/InteractionPanel.jsx
@@ -187,8 +187,7 @@ const InteractionPanel = observer(() => {
       sx={{
         position: "fixed",
         width: "100%",
-        height: `calc(100vh - 78px)`,
-        zIndex: 20,
+        height: "100%",
         overflow: "clip",
         backgroundColor: "#000",
         userSelect: "none",
@@ -206,7 +205,6 @@ const InteractionPanel = observer(() => {
           position: "fixed",
           bottom: 0,
           display: "flex",
-          zIndex: "30",
         }}
       >
         <History />

--- a/src/interaction(legacyJS)/src/Components/views/02. Studio/04. EventPanel/InteractionPanel.jsx
+++ b/src/interaction(legacyJS)/src/Components/views/02. Studio/04. EventPanel/InteractionPanel.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from "react";
-import { observer } from "mobx-react-lite";
+import { observer } from "mobx-react";
 import Box from "@mui/material/Box";
 import storeContainer from "../../../stores/storeContainer";
 import NodeV from "./node/NodeV";

--- a/src/interaction(legacyJS)/src/Components/views/02. Studio/04. EventPanel/ReferenceParameter/NodeReferenceVector3Selector_V.jsx
+++ b/src/interaction(legacyJS)/src/Components/views/02. Studio/04. EventPanel/ReferenceParameter/NodeReferenceVector3Selector_V.jsx
@@ -1,17 +1,20 @@
 import ReferenceTextField from "./TextFieldV";
-import { observer } from "mobx-react-lite";
+import { observer } from "mobx-react";
 
-const NodeReferenceVector3Selector_V = ({ value, setValue, tooltipMessage }) => {
-
+const NodeReferenceVector3Selector_V = ({
+  value,
+  setValue,
+  tooltipMessage,
+}) => {
   const handleSetValueX = (newValue) => {
     setValue({ ...value, x: newValue });
-  }
+  };
   const handleSetValueY = (newValue) => {
     setValue({ ...value, y: newValue });
-  }
+  };
   const handleSetValueZ = (newValue) => {
     setValue({ ...value, z: newValue });
-  }
+  };
 
   return (
     <>
@@ -35,6 +38,6 @@ const NodeReferenceVector3Selector_V = ({ value, setValue, tooltipMessage }) => 
       />
     </>
   );
-}
+};
 
 export default observer(NodeReferenceVector3Selector_V);

--- a/src/interaction(legacyJS)/src/Components/views/02. Studio/04. EventPanel/history-tab/interactionHierarchy.jsx
+++ b/src/interaction(legacyJS)/src/Components/views/02. Studio/04. EventPanel/history-tab/interactionHierarchy.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Tabs, Box, Tab, Typography, createTheme } from "@mui/material";
-import { observer } from "mobx-react-lite";
+import { observer } from "mobx-react";
 import { ThemeProvider } from "@mui/material/styles";
 import InteractionLeftTab from "./interactionLeftTab";
 

--- a/src/interaction(legacyJS)/src/Components/views/02. Studio/04. EventPanel/history-tab/interactionHierarchyList.jsx
+++ b/src/interaction(legacyJS)/src/Components/views/02. Studio/04. EventPanel/history-tab/interactionHierarchyList.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from "react";
 import { List, Box, Button, Typography, Divider } from "@mui/material";
-import { observer } from "mobx-react-lite";
+import { observer } from "mobx-react";
 import storeContainer from "../../../../stores/storeContainer";
 import { reaction } from "mobx";
 import InteractionHierachyVM from "../../../../view_models/05. Hierarchy/InteractionHierarchy_VM";

--- a/src/interaction(legacyJS)/src/Components/views/02. Studio/04. EventPanel/history-tab/interactionHistory.jsx
+++ b/src/interaction(legacyJS)/src/Components/views/02. Studio/04. EventPanel/history-tab/interactionHistory.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Tabs, Box, Tab, Typography, createTheme } from "@mui/material";
-import { observer } from "mobx-react-lite";
+import { observer } from "mobx-react";
 import { ThemeProvider } from "@mui/material/styles";
 import InteractionLeftTab from "./interactionLeftTab";
 

--- a/src/interaction(legacyJS)/src/Components/views/02. Studio/04. EventPanel/history-tab/interactionHistoryList.jsx
+++ b/src/interaction(legacyJS)/src/Components/views/02. Studio/04. EventPanel/history-tab/interactionHistoryList.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Box, Button, Grid, Tooltip } from "@mui/material";
-import { observer } from "mobx-react-lite";
+import { observer } from "mobx-react";
 import storeContainer from "../../../../stores/storeContainer";
 
 const InitialState = (props) => {

--- a/src/interaction(legacyJS)/src/Components/views/02. Studio/04. EventPanel/node-bar/CreateNodeButton.jsx
+++ b/src/interaction(legacyJS)/src/Components/views/02. Studio/04. EventPanel/node-bar/CreateNodeButton.jsx
@@ -1,4 +1,4 @@
-import { observer } from "mobx-react-lite";
+import { observer } from "mobx-react";
 import IconButton from "@mui/material/IconButton";
 import storeContainer from "../../../../stores/storeContainer";
 import CreateNodeCommand from "../../../../class/commands/Interaction/CreateNodeCommand";

--- a/src/interaction(legacyJS)/src/Components/views/02. Studio/04. EventPanel/node-bar/CreateNodeButtonDisabled.jsx
+++ b/src/interaction(legacyJS)/src/Components/views/02. Studio/04. EventPanel/node-bar/CreateNodeButtonDisabled.jsx
@@ -1,4 +1,4 @@
-import { observer } from "mobx-react-lite";
+import { observer } from "mobx-react";
 import IconButton from "@mui/material/IconButton";
 import useIcon from "../../../../hooks/useIcon";
 

--- a/src/interaction(legacyJS)/src/Components/views/02. Studio/04. EventPanel/node-bar/CreateNodeButtonTemp.jsx
+++ b/src/interaction(legacyJS)/src/Components/views/02. Studio/04. EventPanel/node-bar/CreateNodeButtonTemp.jsx
@@ -1,4 +1,4 @@
-import { observer } from "mobx-react-lite";
+import { observer } from "mobx-react";
 import storeContainer from "../../../../stores/storeContainer";
 import Box from "@mui/material/Box";
 import IconButton from "@mui/material/IconButton";

--- a/src/interaction(legacyJS)/src/Components/views/02. Studio/04. EventPanel/node-bar/CreateNodeMenuButtonTemp.jsx
+++ b/src/interaction(legacyJS)/src/Components/views/02. Studio/04. EventPanel/node-bar/CreateNodeMenuButtonTemp.jsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { observer } from "mobx-react-lite";
+import { observer } from "mobx-react";
 import Box from "@mui/material/Box";
 import Menu from "@mui/material/Menu";
 import IconButton from "@mui/material/IconButton";

--- a/src/interaction(legacyJS)/src/Components/views/02. Studio/04. EventPanel/node-bar/CreateNodeMenuItemButton.jsx
+++ b/src/interaction(legacyJS)/src/Components/views/02. Studio/04. EventPanel/node-bar/CreateNodeMenuItemButton.jsx
@@ -1,4 +1,4 @@
-import { observer } from "mobx-react-lite";
+import { observer } from "mobx-react";
 import MenuItem from "@mui/material/MenuItem";
 import storeContainer from "../../../../stores/storeContainer";
 import CreateNodeCommand from "../../../../class/commands/Interaction/CreateNodeCommand";

--- a/src/interaction(legacyJS)/src/Components/views/02. Studio/04. EventPanel/node/Header/UxSelector.jsx
+++ b/src/interaction(legacyJS)/src/Components/views/02. Studio/04. EventPanel/node/Header/UxSelector.jsx
@@ -1,6 +1,6 @@
 import { Input } from "@mui/material";
 import { Box } from "@mui/system";
-import { observer } from "mobx-react-lite";
+import { observer } from "mobx-react";
 import React from "react";
 import { eventSystem_store } from "../../../../../stores/Interaction_Stores";
 

--- a/src/interaction(legacyJS)/src/Components/views/02. Studio/04. EventPanel/view-events/RootVKeyboardEvent.js
+++ b/src/interaction(legacyJS)/src/Components/views/02. Studio/04. EventPanel/view-events/RootVKeyboardEvent.js
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import { observer } from "mobx-react-lite";
+import { observer } from "mobx-react";
 import storeContainer from "../../../../stores/storeContainer";
 import DeleteNodeAndGroupCommand from "../../../../class/commands/Interaction/DeleteNodeAndGroupCommand";
 import CloneNodeAndGroupCommand from "../../../../class/commands/Interaction/CloneNodeAndGroupCommand";

--- a/src/store/editorModeStore.ts
+++ b/src/store/editorModeStore.ts
@@ -4,15 +4,27 @@ type EditorMode = "canvas" | "interaction";
 
 interface EditorModeStoreProps {
   editorMode: EditorMode;
+  canvasBarOpen: boolean;
+  interactionBarOpen: boolean;
   setEditorMode: (mode: EditorMode) => void;
+  toggleCanvasBar: () => void;
+  toggleInteractionBar: () => void;
 }
 
 const editorModeStore = observable<EditorModeStoreProps>({
   editorMode: "canvas",
+  canvasBarOpen: true,
+  interactionBarOpen: true,
   setEditorMode: (mode: EditorMode) => {
     editorModeStore.editorMode = mode;
   },
+  toggleCanvasBar: () => {
+    editorModeStore.canvasBarOpen = !editorModeStore.canvasBarOpen;
+  },
+  toggleInteractionBar: () => {
+    editorModeStore.interactionBarOpen = !editorModeStore.interactionBarOpen;
+  },
 });
 
-export type { EditorModeStoreProps }
+export type { EditorModeStoreProps };
 export default editorModeStore;


### PR DESCRIPTION
## 📌 `Pull Request` 관련 내용 공유

### 📋 PR 설명

- 인터렉션 에디터 레이아웃 수정
- close #73



### 📡 핵심 기능

- 인터렉션 에디터 메뉴바 레이아웃 수정 (TopBar와의 간격 없앰)
- 메뉴바 토글 기능


### 📸 시각 자료(캡처 화면)

![interaction](https://github.com/Rebuild-Studio/Client/assets/53351097/ae2b0ff3-74a5-432b-8743-2ab5f76f944f)




### 🛠️ 이슈 및 앞으로 할 일

-  mobx-react의 디펜던시로 mobx-react-lite가 있어서 지금까지 사용가능했지만 package.json에 명시적으로 적혀있지않아 우선 mobx-react로 모두 변경했습니다.



<br>



## 🤖 `PR` 셀프 체크리스트 🤖

> 코드 확인 후 `[ ]`사이 공백을 `x`로 체크하시오

<br>



### ⌨️ 코드 컨벤션!

- [x] 불필요한 console 디버깅 코드는 제거했나요? (스토리북 예외)
    - `console.log(selectedObject[0])`



- [x] 변수명 혹은 파일명이 너무 추상적이지는 않나요?
  - `setType` -> `setBackgroundColorType ` 



- [x] 불필요한 공백을 제거하셨나요?

    - ```react
      <AppWrapper>
        <MenuBar />
        <Scene />
                          // <- X
      </AppWrapper>
      ```



- [x] 불필요한 주석을 제거하셨나요?

    - ```react
      // primitiveStore.addPrimitive(                          // <- X
      //   storeId,                                            // <- X
      //   renderSelectedGroup(storeId, mesh.clone())          // <- X
      // );                                                    // <- X
      ```



<br>