### PR TITLE
Feat: Showing styled component classname on devtool

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,7 @@
         "@typescript-eslint/eslint-plugin": "^6.0.0",
         "@typescript-eslint/parser": "^6.0.0",
         "@vitejs/plugin-react": "^4.0.3",
+        "babel-plugin-styled-components": "^2.1.4",
         "eslint": "^8.45.0",
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-react-refresh": "^0.4.3",
@@ -9127,6 +9128,22 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+      }
+    },
+    "node_modules/babel-plugin-styled-components": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.1.4.tgz",
+      "integrity": "sha512-Xgp9g+A/cG47sUyRwwYxGM4bR/jDRg5N6it/8+HxCnbT5XNKSKDT9xm4oag/osgqjC2It/vH0yXsomOG6k558g==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.22.5",
+        "@babel/helper-module-imports": "^7.22.5",
+        "@babel/plugin-syntax-jsx": "^7.22.5",
+        "lodash": "^4.17.21",
+        "picomatch": "^2.3.1"
+      },
+      "peerDependencies": {
+        "styled-components": ">= 2"
       }
     },
     "node_modules/babel-preset-current-node-syntax": {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "@typescript-eslint/eslint-plugin": "^6.0.0",
     "@typescript-eslint/parser": "^6.0.0",
     "@vitejs/plugin-react": "^4.0.3",
+    "babel-plugin-styled-components": "^2.1.4",
     "eslint": "^8.45.0",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.3",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
           [
             "babel-plugin-styled-components",
             {
-              displayName: true,
+              displayName: process.env.NODE_ENV !== "production",
               fileName: false,
             },
           ],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,21 @@ import react from "@vitejs/plugin-react";
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react()],
+  plugins: [
+    react({
+      babel: {
+        plugins: [
+          [
+            "babel-plugin-styled-components",
+            {
+              displayName: true,
+              fileName: false,
+            },
+          ],
+        ],
+      },
+    }),
+  ],
   resolve: {
     alias: [
       { find: "@", replacement: "/src" },


### PR DESCRIPTION
## 📌 `Pull Request` 관련 내용 공유

### 📋 PR 설명

- 더 나은 디버깅 환경을 위해 기능추가했습니다

close #141 


### 📡 핵심 기능

- 개발자도구에서 styled component의 클래스네임 볼수 있도록 변경
- production에서는 class name이 (기존처럼) minifying되어있도록 설정


### 📸 시각 자료(캡처 화면)

- 기존
![image](https://github.com/Rebuild-Studio/Client/assets/63194662/756201fc-f505-4904-97f3-773bfa811900)

- 변경 후
![image](https://github.com/Rebuild-Studio/Client/assets/63194662/951428da-f912-4217-9074-9eb8b83e7a31)



### 🛠️ 이슈 및 앞으로 할 일

-  더 좋은환경에서 열씨미 디버깅!



<br>



## 🤖 `PR` 셀프 체크리스트 🤖

> 코드 확인 후 `[ ]`사이 공백을 `x`로 체크하시오

<br>



### ⌨️ 코드 컨벤션!

- [x] 불필요한 console 디버깅 코드는 제거했나요? (스토리북 예외)
    - `console.log(selectedObject[0])`



- [x] 변수명 혹은 파일명이 너무 추상적이지는 않나요?
  - `setType` -> `setBackgroundColorType ` 



- [x] 불필요한 공백을 제거하셨나요?

    - ```react
      <AppWrapper>
        <MenuBar />
        <Scene />
                          // <- X
      </AppWrapper>
      ```



- [x] 불필요한 주석을 제거하셨나요?

    - ```react
      // primitiveStore.addPrimitive(                          // <- X
      //   storeId,                                            // <- X
      //   renderSelectedGroup(storeId, mesh.clone())          // <- X
      // );                                                    // <- X
      ```



<br>