### PR TITLE
style: 패널 스크롤 가능하게 변경

### DIFF
--- a/src/components/layout/Panel/Panel.tsx
+++ b/src/components/layout/Panel/Panel.tsx
@@ -28,7 +28,9 @@ const PanelWrapper = styled.div`
   box-sizing: border-box;
   height: 100%;
   background-color: ${bgColors[222222]};
-  display: inline-block;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
   z-index: 1;
   width: 271px;
   padding: 10px 0;
@@ -36,7 +38,6 @@ const PanelWrapper = styled.div`
 `;
 
 const PanelTitleWrapper = styled.div`
-  padding: 0 10px;
   color: white;
   font-weight: 700;
   font-size: ${fonts.default};
@@ -63,8 +64,9 @@ const PanelOptionsWrapper = styled.div`
 `;
 
 const PanelContentWrapper = styled.div`
+  flex: 1;
+  overflow-y: auto;
   padding: 0 10px;
-  box-sizing: inherit;
   color: white;
   font-size: ${fonts.small};
 `;

--- a/src/components/layout/Tools.tsx
+++ b/src/components/layout/Tools.tsx
@@ -55,17 +55,25 @@ const Top = styled.div`
 `;
 
 const Bottom = styled.div`
+  flex: 1;
   display: flex;
   justify-content: space-between;
-  height: 100%;
+  position: relative;
 `;
 
-const Left = styled.div``;
+const Left = styled.div`
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  height: 100%;
+`;
 
 const Right = styled.div`
   display: flex;
   pointer-events: none;
-  position: relative;
+  position: absolute;
+  right: 0;
+  height: 100%;
 `;
 
 const OrientationHelperWrapper = styled.div`


### PR DESCRIPTION
## 📌 `Pull Request` 관련 내용 공유

### 📋 PR 설명

- 창 높이가 작을 시 패널 때문에 스크롤이 생기는 현상을 고치기 위해 패널 자체를 스크롤 가능하게 변경



### 📡 핵심 기능

- 패널 스크롤 가능



### 📸 시각 자료(캡처 화면)

<img width="303" alt="스크린샷 2023-10-25 오후 3 31 29" src="https://github.com/Rebuild-Studio/Client/assets/53351097/2918c873-7e61-4666-84e5-cf83ab9be875">




### 🛠️ 이슈 및 앞으로 할 일

- 



<br>



## 🤖 `PR` 셀프 체크리스트 🤖

> 코드 확인 후 `[ ]`사이 공백을 `x`로 체크하시오

<br>



### ⌨️ 코드 컨벤션!

- [x] 불필요한 console 디버깅 코드는 제거했나요? (스토리북 예외)
    - `console.log(selectedObject[0])`



- [x] 변수명 혹은 파일명이 너무 추상적이지는 않나요?
  - `setType` -> `setBackgroundColorType ` 



- [x] 불필요한 공백을 제거하셨나요?

    - ```react
      <AppWrapper>
        <MenuBar />
        <Scene />
                          // <- X
      </AppWrapper>
      ```



- [x] 불필요한 주석을 제거하셨나요?

    - ```react
      // primitiveStore.addPrimitive(                          // <- X
      //   storeId,                                            // <- X
      //   renderSelectedGroup(storeId, mesh.clone())          // <- X
      // );                                                    // <- X
      ```



<br>