### PR TITLE
fix: 환경 이미지 모달 잘리는 버그

### DIFF
--- a/src/components/layout/Accordion.tsx
+++ b/src/components/layout/Accordion.tsx
@@ -43,7 +43,6 @@ export default Accordion;
 const AccordionContainer = styled.div`
   width: 100%;
   margin-top: 10px;
-  overflow: hidden;
   position: relative;
 `;
 
@@ -82,7 +81,6 @@ const AccordionContent = styled.div<{
   $isOpen: boolean;
   $maxHeight: number | null;
 }>`
-  overflow: hidden;
   max-height: ${(props) => props.$maxHeight};
   transition: max-height 0.3s ease-in-out;
   opacity: ${(props) => (props.$isOpen ? "1" : "0")};

--- a/src/components/layout/Menu.tsx
+++ b/src/components/layout/Menu.tsx
@@ -61,6 +61,7 @@ export default CustomMenu;
 
 const Wrapper = styled.div`
   display: flex;
+  position: relative;
 `;
 const TitleWrapper = styled.div`
   display: flex;

--- a/src/components/layout/Panel/Panel.tsx
+++ b/src/components/layout/Panel/Panel.tsx
@@ -65,7 +65,6 @@ const PanelOptionsWrapper = styled.div`
 
 const PanelContentWrapper = styled.div`
   flex: 1;
-  overflow-y: auto;
   padding: 0 10px;
   color: white;
   font-size: ${fonts.small};


### PR DESCRIPTION
## 📌 `Pull Request` 관련 내용 공유

### 📋 PR 설명

- close #148 



### 📡 핵심 기능

- 



### 📸 시각 자료(캡처 화면)
before
<img width="609" alt="before" src="https://github.com/Rebuild-Studio/Client/assets/53351097/49927b3d-0e60-4bc3-944b-072938f18c0d">


after
<img width="609" alt="after" src="https://github.com/Rebuild-Studio/Client/assets/53351097/b6fb5cb0-1f67-400c-b7a4-04e6a0afb96e">




### 🛠️ 이슈 및 앞으로 할 일

- 모달 위치 조정



<br>



## 🤖 `PR` 셀프 체크리스트 🤖

> 코드 확인 후 `[ ]`사이 공백을 `x`로 체크하시오

<br>



### ⌨️ 코드 컨벤션!

- [x] 불필요한 console 디버깅 코드는 제거했나요? (스토리북 예외)
    - `console.log(selectedObject[0])`



- [x] 변수명 혹은 파일명이 너무 추상적이지는 않나요?
  - `setType` -> `setBackgroundColorType ` 



- [x] 불필요한 공백을 제거하셨나요?

    - ```react
      <AppWrapper>
        <MenuBar />
        <Scene />
                          // <- X
      </AppWrapper>
      ```



- [x] 불필요한 주석을 제거하셨나요?

    - ```react
      // primitiveStore.addPrimitive(                          // <- X
      //   storeId,                                            // <- X
      //   renderSelectedGroup(storeId, mesh.clone())          // <- X
      // );                                                    // <- X
      ```



<br>