### PR TITLE
fix : 환경이미지 사용 하지 않을 때 슬라이더 비활성화

### DIFF
--- a/src/components/common/RightPanel/sceneSetting/HdriSetting.tsx
+++ b/src/components/common/RightPanel/sceneSetting/HdriSetting.tsx
@@ -75,6 +75,7 @@ const HdriSetting = () => {
           max={5}
           title={'환경강도'}
           step={0.1}
+          disabled={!sceneSettingStore.hdriToggle}
         />
         <Slider
           initValue={sceneSettingStore.hdriYRotation}
@@ -83,6 +84,7 @@ const HdriSetting = () => {
           min={0}
           max={360}
           step={0.1}
+          disabled={!sceneSettingStore.hdriToggle}
         />
       </Accordion>
       <Accordion title={'주변광'}>


### PR DESCRIPTION
## 📌 `Pull Request` 관련 내용 공유

### 📋 PR 설명

- close #140 



### 📡 핵심 기능

- 환경이미지 사용 하지 않을 때 슬라이더 비활성화



### 📸 시각 자료(캡처 화면)





### 🛠️ 이슈 및 앞으로 할 일

- 



<br>



## 🤖 `PR` 셀프 체크리스트 🤖

> 코드 확인 후 `[ ]`사이 공백을 `x`로 체크하시오

<br>



### ⌨️ 코드 컨벤션!

- [x] 불필요한 console 디버깅 코드는 제거했나요? (스토리북 예외)
    - `console.log(selectedObject[0])`



- [x] 변수명 혹은 파일명이 너무 추상적이지는 않나요?
  - `setType` -> `setBackgroundColorType ` 



- [x] 불필요한 공백을 제거하셨나요?

    - ```react
      <AppWrapper>
        <MenuBar />
        <Scene />
                          // <- X
      </AppWrapper>
      ```



- [x] 불필요한 주석을 제거하셨나요?

    - ```react
      // primitiveStore.addPrimitive(                          // <- X
      //   storeId,                                            // <- X
      //   renderSelectedGroup(storeId, mesh.clone())          // <- X
      // );                                                    // <- X
      ```



<br>