### PR TITLE
변수노드-넘버(variableNumberNode) 사용 시 터지는 문제 해결=>Mui Input color 속성 문제로 확인.

### DIFF
--- a/src/interaction(legacyJS)/src/Components/views/02. Studio/04. EventPanel/node/Header/UxSelector.jsx
+++ b/src/interaction(legacyJS)/src/Components/views/02. Studio/04. EventPanel/node/Header/UxSelector.jsx
@@ -1,8 +1,17 @@
 import React from 'react';
 import { observer } from 'mobx-react';
 import { Input } from '@mui/material';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
 import { Box } from '@mui/system';
 import { eventSystem_store } from '../../../../../stores/Interaction_Stores';
+
+const theme = createTheme({
+  palette: {
+    primary: {
+      main: '#ffffff'
+    }
+  }
+});
 
 /**
  * @typedef {object} UxSelectorProps
@@ -20,13 +29,14 @@ const UxSelector = observer(({ node }) => {
     <Box sx={style.Container(scale)}>
       <Box sx={style.KeyInputContainer}>
         <span>키 이름</span>
-        <Input
-          onChange={handleSelectorChange}
-          sx={style.Input}
-          placeholder="MY_KEY"
-          color="white"
-          value={node.uxSelector}
-        />
+        <ThemeProvider theme={theme}>
+          <Input
+            onChange={handleSelectorChange}
+            sx={style.Input}
+            placeholder="MY_KEY"
+            value={node.uxSelector}
+          />
+        </ThemeProvider>
       </Box>
     </Box>
   );


### PR DESCRIPTION
## 📌 `Pull Request` 관련 내용 공유

### 📋 PR 설명

- 변수노드-넘버(variableNumberNode) 사용 시 터지는 문제 해결



### 📡 핵심 기능

- ThemeProvider, createTheme를 활용하여 Mui Input 속성 추가



### 📸 시각 자료(캡처 화면)
![image](https://github.com/Rebuild-Studio/Client/assets/97646070/53c0234a-72c4-4617-80c5-72dc07f3c2fc)





### 🛠️ 이슈 및 앞으로 할 일

- 노드에 한글만 입력되는 버그 발견. 추후 논의 후 해결 예정.



<br>



## 🤖 `PR` 셀프 체크리스트 🤖

> 코드 확인 후 `[ ]`사이 공백을 `x`로 체크하시오

<br>



### ⌨️ 코드 컨벤션!

- [x] 불필요한 console 디버깅 코드는 제거했나요? (스토리북 예외)
    - `console.log(selectedObject[0])`



- [x] 변수명 혹은 파일명이 너무 추상적이지는 않나요?
  - `setType` -> `setBackgroundColorType ` 



- [x] 불필요한 공백을 제거하셨나요?

    - ```react
      <AppWrapper>
        <MenuBar />
        <Scene />
                          // <- X
      </AppWrapper>
      ```



- [x] 불필요한 주석을 제거하셨나요?

    - ```react
      // primitiveStore.addPrimitive(                          // <- X
      //   storeId,                                            // <- X
      //   renderSelectedGroup(storeId, mesh.clone())          // <- X
      // );                                                    // <- X
      ```


close #191 
<br>